### PR TITLE
Removing log ingest rules from environment level. 

### DIFF
--- a/dynatrace_log_storage/README.md
+++ b/dynatrace_log_storage/README.md
@@ -1,0 +1,21 @@
+# Dynatrace Log Storage Module
+
+This module can be used to set Environment level Dynatrace Log Storage settings.
+It allows you to include or exclude logs based on specific attributes, such as Kubernetes pod labels.
+
+Log ingest rules can be defined at host, host group, or environment level. Ideally you would use host rules to include or exclude logs from specific hosts, but in some cases, you may want to apply rules at the environment level.
+
+# Example Usage
+```
+module "dynatrace_log_storage_include_dynatrace_labelled_pods" {
+  source          = "./dynatrace_log_storage"
+  name            = "Include Dynatrace Labelled Pods"
+  enabled         = true
+  send_to_storage = true
+
+// DT docs are wrong - Use https://github.com/dynatrace-oss/terraform-provider-dynatrace/blob/a02c5b5b61cfc1d216508202ec7e4f6bd4787069/dynatrace/api/builtin/logmonitoring/logstoragesettings/settings/enums.go#L47-L69 for valid values
+  matcher_attribute = "k8s.pod.label"
+  matcher_operator  = "MATCHES"
+  matcher_values    = ["dynatrace-logs=true"]
+}
+```

--- a/dynatrace_log_storage/main.tf
+++ b/dynatrace_log_storage/main.tf
@@ -1,6 +1,6 @@
 
 
-resource "dynatrace_log_storage" "include_dynatrace_labelled_pods" {
+resource "dynatrace_log_storage" "dynatrace_log_storage_rule" {
   name            = var.name
   enabled         = var.enabled
   send_to_storage = var.send_to_storage

--- a/main.tf
+++ b/main.tf
@@ -95,17 +95,6 @@ module "dynatrace_servicenow_integration" {
   ) ? var.tenant_vars.servicenow_integration.snow_integration_state : "false"
 }
 
-module "dynatrace_log_storage_include_dynatrace_labelled_pods" {
-  source          = "./dynatrace_log_storage"
-  name            = "Include Dynatrace Labelled Pods"
-  enabled         = true
-  send_to_storage = true
-
-  matcher_attribute = "K8s_pod_label"
-  matcher_operator  = "MATCHES"
-  matcher_values    = ["dynatrace-logs:true"]
-}
-
 module "dynatrace_aws_monitoring_profile_integration" {
   source = "./alerts/aws_monitoring_profile"
   count = contains(


### PR DESCRIPTION
We do not need to define log ingest rules at the environment level. They will be defined at host (OneAgent) level. 

Log ingest rules can be defined at three scopes: host, host group, and environment, with host scope rules having the highest priority. [[Source](https://docs.dynatrace.com/docs/analyze-explore-automate/logs/lma-log-ingestion/lma-log-ingestion-via-oa/lma-log-storage-configuration#log-ingest-rules)]

