### PR TITLE
update memory threshold from 2 to 90

### DIFF
--- a/anomaly_detection/k8s_workload_anomalies.tf
+++ b/anomaly_detection/k8s_workload_anomalies.tf
@@ -65,7 +65,7 @@ resource "dynatrace_k8s_workload_anomalies" "core-cloud-k8s-workload-anomalies" 
     configuration {
       observation_period_in_minutes = 6
       sample_period_in_minutes      = 4
-      threshold                     = 2
+      threshold                     = 90
     }
   }
   job_failure_events {


### PR DESCRIPTION
Updating k8s workload memory usage problem threshold to 90% from 2%. This should resolve most of the current problems across CC EKS estate 